### PR TITLE
Fix permissions for workflow

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
The softprops/action-gh-release step used by the release workflow requires `contents:write`